### PR TITLE
Update class.uFlex.php

### DIFF
--- a/class.uFlex.php
+++ b/class.uFlex.php
@@ -366,7 +366,7 @@ class uFlex{
 			
 			$this->make_hash($user['user_id']);
 			$this->id = $user['user_id'];
-			$this->save_hash();
+			$this->save_hash(true);
 
 			$data = array(
 				"email" => $email, 
@@ -946,9 +946,9 @@ class uFlex{
 	/**
 	 * Saves the confirmation hash in the database
 	 */
-	function save_hash(){
+	function save_hash($activated = false){
 		if($this->confirm and $this->id){
-			$sql = "UPDATE :table SET confirmation=:hash, activated=0 WHERE user_id=:id";
+			$sql = "UPDATE :table SET confirmation=:hash, activated=".(($activated)?'activated':0)." WHERE user_id=:id";
 			$data = Array(
 				"id"	=> $this->id,
 				"hash"	=> $this->confirm


### PR DESCRIPTION
If i request a password reset on your email address you can't login till you deal with the mechanism to reset your password.
If i flood the password reset routine with requests for your email address you're affectively locked out.

This mod allows an active user (with the correct password) to login even if a password reset has been requested.
