### PR TITLE
changed sequence in hash_pass

### DIFF
--- a/class.uFlex.php
+++ b/class.uFlex.php
@@ -744,11 +744,11 @@ class uFlex{
 		
 		$regdate = false;
 		
-		if(isset($this->data['reg_date']))
-			$regdate = $this->data['reg_date'];
-		
-		if(!$regdate and isset($this->tmp_data['reg_date']))
+		if(isset($this->tmp_data['reg_date']))
 			$regdate = $this->tmp_data['reg_date'];
+		
+		if(!$regdate and isset($this->data['reg_date']))
+			$regdate = $this->data['reg_date'];
 		
 		if(!$regdate){
 			return $this->legacy_hash_pass($pass);


### PR DESCRIPTION
Reason is - it makes possible to make pages where logged in users can add users to the system, not only a free for all registration page but a closed system. Shouldn't break anything AFAIS tmp_data is set rarely and hash_pass can't break it, take a look though.
