### PR TITLE
Fixed error where rowCount() (PDO) is used for SELECT statements.

### DIFF
--- a/class.uFlex.php
+++ b/class.uFlex.php
@@ -1224,6 +1224,9 @@
 
 			$rows = $st->rowCount();
 
+			// rowCount() will return 0 for SELECT statements for some SQL engines.
+			$rows = ($rows>0) ? $rows : count($st->fetchAll());
+
 			if($rows > 0){
 				//Good, Rows where affected
 				$this->report("$rows row(s) where Affected");
@@ -1248,12 +1251,14 @@
 
 			if(!$st) return false;
 
-			if(!$st->rowCount()){
+			$result = $st->fetch(PDO::FETCH_ASSOC);
+
+			if(!$result){
 				$this->report("Query returned empty");
 				return false;
 			}
 
-			return $st->fetch(PDO::FETCH_ASSOC);
+			return $result;
 		}
 
 		/**

--- a/demo/core/inc/class.uFlex.php
+++ b/demo/core/inc/class.uFlex.php
@@ -1222,6 +1222,9 @@
 
 			$rows = $st->rowCount();
 
+			// rowCount() will return 0 for SELECT statements for some SQL engines.
+			$rows = ($rows>0) ? $rows : count($st->fetchAll());
+
 			if($rows > 0){
 				//Good, Rows where affected
 				$this->report("$rows row(s) where Affected");
@@ -1246,12 +1249,14 @@
 
 			if(!$st) return false;
 
-			if(!$st->rowCount()){
+			$result = $st->fetch(PDO::FETCH_ASSOC);
+
+			if(!$result){
 				$this->report("Query returned empty");
 				return false;
 			}
 
-			return $st->fetch(PDO::FETCH_ASSOC);
+			return $result;
 		}
 
 		/**

--- a/demo_old/core/inc/class.uFlex.php
+++ b/demo_old/core/inc/class.uFlex.php
@@ -1222,6 +1222,9 @@
 
 			$rows = $st->rowCount();
 
+			// rowCount() will return 0 for SELECT statements for some SQL engines.
+			$rows = ($rows>0) ? $rows : count($st->fetchAll());
+
 			if($rows > 0){
 				//Good, Rows where affected
 				$this->report("$rows row(s) where Affected");
@@ -1246,12 +1249,14 @@
 
 			if(!$st) return false;
 
-			if(!$st->rowCount()){
+			$result = $st->fetch(PDO::FETCH_ASSOC);
+
+			if(!$result){
 				$this->report("Query returned empty");
 				return false;
 			}
 
-			return $st->fetch(PDO::FETCH_ASSOC);
+			return $result;
 		}
 
 		/**


### PR DESCRIPTION
As per our earlier discussion. SQL engines like SQLite (and others) will not correctly return rowCount() for queries that do not modify the database. The rowCount() strategy in `check_sql` and `getRow` has been replaced and augmented so that this code works correctly with these engines.
