### PR TITLE
Make User:logLogin public

### DIFF
--- a/src/User.php
+++ b/src/User.php
@@ -287,7 +287,7 @@ class User extends UserBase
      *
      * @ignore
      */
-    protected function logLogin()
+    public function logLogin()
     {
         //Update last_login
         $time = time();


### PR DESCRIPTION
I am planning to add an IP column, but to do that I need the logLogin function public, so that child classes can implement it as well.