### PR TITLE
Fix demo reset password confirmation (issue #32)

### DIFF
--- a/demo/ps/reset_password.php
+++ b/demo/ps/reset_password.php
@@ -1,35 +1,37 @@
 <?php
-    include("../core/config.php");
-
-    //Process Update
-    if(count($_POST)){
+	include("../core/config.php");
+	
+	//Process Update
+	if(count($_POST)){
         /*
          * Covert POST into a Collection object
          * for better handling
          */
         $input = new \ptejada\uFlex\Collection($_POST);
 
-        $res = $user->resetPassword($input->Email);
+		$res = $user->resetPassword($input->Email);
 
-        $errorMessage = '';
-        $confirmMessage = '';
+		$errorMessage = '';
+		$confirmMessage = '';
 
-        if($res){
-            //Hash succesfully generated
-            //You would send an email to $res['Email'] with the URL+HASH $res['hash'] to enter the new Password
-            //In this demo we will just redirect the user directly
+		if($res){
+			//Hash succesfully generated
+			//You would send an email to $res['Email'] with the URL+HASH $res['hash'] to enter the new Password
+			//In this demo we will just redirect the user directly
+			
+			$url = 'account/update/password?c=' . $res->Confirmation;
+			$confirmMessage = "Use the link below to change your password <a href='{$url}'>Change Password</a>";
 
-            $url = 'account/update/password?c=' . $res->Confirmation;
-            $confirmMessage = "Use the link below to change your password <a href='{$url}'>Change Password</a>";
+		}else{
+			$errorMessage = $user->log->getErrors();
+			$errorMessage = $errorMessage[0];
+		}
 
-        }else{
-            $errorMessage = $user->log->getErrors();
-            $errorMessage = $errorMessage[0];
-        }
-
-        echo json_encode(array(
-            'error'    => $user->log->getErrors(),
-            'confirm'  => $confirmMessage,
-            'form'     => $user->log->getFormErrors(),
-        ));
-    }
+		echo json_encode(array(
+			'error'    => $user->log->getErrors(),
+			'confirm'  => $confirmMessage,
+			'form'    => array(
+				'Email' => $errorMessage
+			)
+		));
+	}

--- a/demo/ps/reset_password.php
+++ b/demo/ps/reset_password.php
@@ -1,37 +1,35 @@
 <?php
-	include("../core/config.php");
-	
-	//Process Update
-	if(count($_POST)){
+    include("../core/config.php");
+
+    //Process Update
+    if(count($_POST)){
         /*
          * Covert POST into a Collection object
          * for better handling
          */
         $input = new \ptejada\uFlex\Collection($_POST);
 
-		$res = $user->resetPassword($input->Email);
+        $res = $user->resetPassword($input->Email);
 
-		$errorMessage = '';
-		$confirmMessage = '';
+        $errorMessage = '';
+        $confirmMessage = '';
 
-		if($res){
-			//Hash succesfully generated
-			//You would send an email to $res['Email'] with the URL+HASH $res['hash'] to enter the new Password
-			//In this demo we will just redirect the user directly
-			
-			$url = 'account/update/password?c=' . $res->Confirmation;
-			$confirmMessage = "Use the link below to change your password <a href='{$url}'>Change Password</a>";
+        if($res){
+            //Hash succesfully generated
+            //You would send an email to $res['Email'] with the URL+HASH $res['hash'] to enter the new Password
+            //In this demo we will just redirect the user directly
 
-		}else{
-			$errorMessage = $user->log->getErrors();
-			$errorMessage = $errorMessage[0];
-		}
+            $url = 'account/update/password?c=' . $res->Confirmation;
+            $confirmMessage = "Use the link below to change your password <a href='{$url}'>Change Password</a>";
 
-		echo json_encode(array(
-			'error'    => $user->log->getErrors(),
-			'confirm'  => $confirmMessage,
-			'form'    => array(
-				'Email' => $errorMessage
-			)
-		));
-	}
+        }else{
+            $errorMessage = $user->log->getErrors();
+            $errorMessage = $errorMessage[0];
+        }
+
+        echo json_encode(array(
+            'error'    => $user->log->getErrors(),
+            'confirm'  => $confirmMessage,
+            'form'     => $user->log->getFormErrors(),
+        ));
+    }

--- a/demo/ps/reset_password.php
+++ b/demo/ps/reset_password.php
@@ -30,8 +30,6 @@
 		echo json_encode(array(
 			'error'    => $user->log->getErrors(),
 			'confirm'  => $confirmMessage,
-			'form'    => array(
-				'Email' => $errorMessage
-			)
+			'form'     => $user->log->getFormErrors(),
 		));
 	}

--- a/src/User.php
+++ b/src/User.php
@@ -583,7 +583,6 @@ class User extends UserBase
             );
         } else {
             $this->log->error(4);
-            $this->log->formError('Email', $this->errorList[4]);
             return false;
         }
     }

--- a/src/User.php
+++ b/src/User.php
@@ -583,6 +583,7 @@ class User extends UserBase
             );
         } else {
             $this->log->error(4);
+            $this->log->formError('Email', $this->errorList[4]);
             return false;
         }
     }

--- a/src/User.php
+++ b/src/User.php
@@ -582,7 +582,7 @@ class User extends UserBase
                 )
             );
         } else {
-            $this->log->error(4);
+            $this->log->formError('Email', $this->errorList[4]);
             return false;
         }
     }


### PR DESCRIPTION
Closes #32. Updates JSON array encode on reset_password.php to match
other demo pages. Updates
user.php to output correct form error. Resubmitting with fix for last
PRs double error output and whitespace madness